### PR TITLE
revert database to original version & fix insertion error

### DIFF
--- a/rattlesnake/settings.py
+++ b/rattlesnake/settings.py
@@ -51,6 +51,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -78,6 +79,12 @@ WSGI_APPLICATION = 'rattlesnake.wsgi.application'
 
 
 # Database
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
 


### PR DESCRIPTION
Each element in the `databases` dict must itself be a dict. You have overwritten the `default` entry to just be a string. Since django using sqlite3 and the default database name, you should just revert to the original version of the setting. 

and I also tried to fix the other errors in the `middleware` configuration in your project app. I would appreciate it if you review my code.